### PR TITLE
Rename Pragmatic post to avoid conflict with repo

### DIFF
--- a/_posts/2013-11-09-pragmatic-programmer-presentation.md
+++ b/_posts/2013-11-09-pragmatic-programmer-presentation.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-title: "Pragmatic Programmer Slideshow"
+title: "Pragmatic Programmer Presentation"
 ---
+
+# Pragmatic Programmer Presentation
 
 I created a slideshow presentation for the book [The Pragmatic Programmer: From Journeyman to Master](http://www.amazon.com/The-Pragmatic-Programmer-Journeyman-Master/dp/020161622X) by Andrew Hunt and David Thomas [here](http://bpruitt-goddard.github.io/pragmatic-programmer-slideshow/).


### PR DESCRIPTION
The blog post was conflicting with the associated repository presentation once the dates were removed from the blog post URLS from [this commit](https://github.com/bpruitt-goddard/bpruitt-goddard.github.io/commit/c2730b9d9109240ff0d1fe3ff5cd3ca5a395b604).
